### PR TITLE
Added ability to add custom headers to reports, so we can use options…

### DIFF
--- a/adwords/report.js
+++ b/adwords/report.js
@@ -37,7 +37,7 @@ class AdwordsReport {
 
         apiVersion = apiVersion || AdwordsConstants.DEFAULT_ADWORDS_VERSION;
 
-        this.getHeaders((error, headers) => {
+        this.getHeaders(report.headers, (error, headers) => {
             if (error) {
                 return callback(error);
             }
@@ -64,11 +64,10 @@ class AdwordsReport {
         });
     }
 
-
     /**
      * Gets the headers for the request
      */
-    getHeaders(callback) {
+    getHeaders(reportHeaders, callback) {
         this.getAccessToken((error, accessToken) => {
             if (error) {
                 return callback(error);
@@ -78,6 +77,9 @@ class AdwordsReport {
                 developerToken: this.credentials.developerToken,
                 clientCustomerId: this.credentials.clientCustomerId
             };
+	    for (var customHeader in reportHeaders) {
+                headers[customHeader] = reportHeaders[customHeader];
+            }
             return callback(null, headers);
         });
     }

--- a/adwords/report.js
+++ b/adwords/report.js
@@ -37,7 +37,7 @@ class AdwordsReport {
 
         apiVersion = apiVersion || AdwordsConstants.DEFAULT_ADWORDS_VERSION;
 
-        this.getHeaders(report.headers, (error, headers) => {
+        this.getHeaders(report.additionalHeaders, (error, headers) => {
             if (error) {
                 return callback(error);
             }
@@ -67,7 +67,7 @@ class AdwordsReport {
     /**
      * Gets the headers for the request
      */
-    getHeaders(reportHeaders, callback) {
+    getHeaders(additionalHeaders, callback) {
         this.getAccessToken((error, accessToken) => {
             if (error) {
                 return callback(error);
@@ -77,9 +77,7 @@ class AdwordsReport {
                 developerToken: this.credentials.developerToken,
                 clientCustomerId: this.credentials.clientCustomerId
             };
-	    for (var customHeader in reportHeaders) {
-                headers[customHeader] = reportHeaders[customHeader];
-            }
+            Object.assign(headers, additionalHeaders);
             return callback(null, headers);
         });
     }


### PR DESCRIPTION
… like skipReportHeader

HI thanks for the awesome work!

I added this to be able to use custom option headers in reports.

For example, you can use skipReportHeader to skip the name of the report or skipReportSummary to skip the summary or skipColumnHeader to skip the row of column names.

It is used like this:

var report = new AdwordsReport(userJson);
report.getReport('v201607', {
    reportName: 'Custom Adgroup Performance Report',
    reportType: 'CAMPAIGN_PERFORMANCE_REPORT',
    headers: {'skipReportHeader': true, 'skipReportSummary': true},
    fields: ['CampaignId', 'Impressions', 'Clicks', 'Cost'],
    filters: [
        {field: 'CampaignStatus', operator: 'IN', values: ['ENABLED', 'PAUSED']}
    ],
    startDate: new Date("07/10/2016"),
    endDate: new Date(),
    format: 'TSV' //defaults to CSV
}, (error, report) => {
    console.log(error, report);
});
