### PR TITLE
Make field clientCustomerId optional in RequestHeader

### DIFF
--- a/adwords/service.js
+++ b/adwords/service.js
@@ -122,14 +122,19 @@ class AdwordsService {
             clientDetails.methods = _.keys(clientDetails.description[clientDetails.name][clientDetails.port]);
             this.clientDetails = clientDetails;
 
-            this.client.addSoapHeader({
+            var header = {
                 RequestHeader: {
                     developerToken: this.credentials.developerToken,
                     userAgent: this.credentials.userAgent,
-                    clientCustomerId: this.credentials.clientCustomerId,
                     validateOnly: !!this.credentials.validateOnly
                 }
-            },
+            };
+
+            if (this.credentials.clientCustomerId) {
+                header.RequestHeader.clientCustomerId = this.credentials.clientCustomerId;
+            }
+
+            this.client.addSoapHeader(header,
             this.clientDetails.name,
             this.clientDetails.namespace,
             this.serviceDescriptor.xmlns);


### PR DESCRIPTION
This feature allow call CustomerService.getCustomers and get clientCustomerId by access_token (or refresh_token/client_id/client_secret). This is very useful for the implementation of integration with AdWords.