### PR TITLE
added ability to define a report via AWQL

### DIFF
--- a/adwords/report.js
+++ b/adwords/report.js
@@ -43,14 +43,24 @@ class AdwordsReport {
                 return callback(error);
             }
             var b = new AdwordsReportBuilder();
-            var xml = b.buildReport(report);
+
+            var formData = null;
+            if (!!report.query) {
+              formData = {
+                '__rdquery': report.query,
+                '__fmt': report.format || 'CSV'
+              }
+            } else {
+              formData = {
+                '__rdxml': b.buildReport(report)
+              }
+            }
+
             request({
-                uri: 'https://adwords.google.com/api/adwords/reportdownload/' + apiVersion,
-                method: 'POST',
-                headers: headers,
-                form: {
-                    '__rdxml': xml
-                }
+              uri: 'https://adwords.google.com/api/adwords/reportdownload/' + apiVersion,
+              method: 'POST',
+              headers: headers,
+              form: formData
             }, (error, response, body) => {
                 if (error || this.reportBodyContainsError(report, body)) {
                     error = error || body;

--- a/test/adwords/services/reporting.js
+++ b/test/adwords/services/reporting.js
@@ -12,59 +12,81 @@ describe('ReportService', function() {
         return console.log('Adwords User not configured, skipping ReportService Service tests');
     }
 
+    describe('when definined via XML', function(){
+        it('should return a valid report', function(done) {
+            let report = new AdwordsReport(config);
 
-    it('should return a valid report', function(done) {
-        let report = new AdwordsReport(config);
+            report.getReport('v201702', {
+                reportName: 'Custom Adgroup Performance Report',
+                reportType: 'CAMPAIGN_PERFORMANCE_REPORT',
+                fields: ['CampaignId', 'Impressions', 'Clicks', 'Cost'],
+                filters: [
+                    {field: 'CampaignStatus', operator: 'IN', values: ['ENABLED', 'PAUSED']}
+                ],
+                startDate: new Date("07/10/2016"),
+                endDate: new Date(),
+                format: 'CSV' //defaults to CSV
+            }, done);
+        });
 
-        report.getReport('v201702', {
-            reportName: 'Custom Adgroup Performance Report',
-            reportType: 'CAMPAIGN_PERFORMANCE_REPORT',
-            fields: ['CampaignId', 'Impressions', 'Clicks', 'Cost'],
-            filters: [
-                {field: 'CampaignStatus', operator: 'IN', values: ['ENABLED', 'PAUSED']}
-            ],
-            startDate: new Date("07/10/2016"),
-            endDate: new Date(),
-            format: 'CSV' //defaults to CSV
-        }, done);
-    });
+        it('should return a valid report for xml type reports', function(done) {
+            let report = new AdwordsReport(config);
 
-    it('should return a valid report for xml type reports', function(done) {
-        let report = new AdwordsReport(config);
+            report.getReport('v201702', {
+                reportName: 'Custom Adgroup Performance Report',
+                reportType: 'CAMPAIGN_PERFORMANCE_REPORT',
+                fields: ['CampaignId', 'Impressions', 'Clicks', 'Cost'],
+                filters: [
+                    {field: 'CampaignStatus', operator: 'IN', values: ['ENABLED', 'PAUSED']}
+                ],
+                startDate: new Date("07/10/2016"),
+                endDate: new Date(),
+                format: 'XML'
+            }, done);
+        });
 
-        report.getReport('v201702', {
-            reportName: 'Custom Adgroup Performance Report',
-            reportType: 'CAMPAIGN_PERFORMANCE_REPORT',
-            fields: ['CampaignId', 'Impressions', 'Clicks', 'Cost'],
-            filters: [
-                {field: 'CampaignStatus', operator: 'IN', values: ['ENABLED', 'PAUSED']}
-            ],
-            startDate: new Date("07/10/2016"),
-            endDate: new Date(),
-            format: 'XML'
-        }, done);
-    });
-
-    it('should return an invalid report for a bad access token', function(done) {
-        let newConfig = _.clone(config);
-        newConfig.refresh_token = null;
-        newConfig.access_token = null;
-        let report = new AdwordsReport(newConfig);
-        report.getReport('v201702', {
-            reportName: 'Custom Adgroup Performance Report',
-            reportType: 'CAMPAIGN_PERFORMANCE_REPORT',
-            fields: ['CampaignId', 'Impressions', 'Clicks', 'Cost'],
-            filters: [
-                {field: 'CampaignStatus', operator: 'IN', values: ['ENABLED', 'PAUSED']}
-            ],
-            startDate: new Date("07/10/2016"),
-            endDate: new Date(),
-            format: 'XML'
-        }, (error, data) => {
-            if (error) {
-                return done();
-            }
-            done(new Error('Should have errored with bad access token'));
+        it('should return an invalid report for a bad access token', function(done) {
+            let newConfig = _.clone(config);
+            newConfig.refresh_token = null;
+            newConfig.access_token = null;
+            let report = new AdwordsReport(newConfig);
+            report.getReport('v201702', {
+                reportName: 'Custom Adgroup Performance Report',
+                reportType: 'CAMPAIGN_PERFORMANCE_REPORT',
+                fields: ['CampaignId', 'Impressions', 'Clicks', 'Cost'],
+                filters: [
+                    {field: 'CampaignStatus', operator: 'IN', values: ['ENABLED', 'PAUSED']}
+                ],
+                startDate: new Date("07/10/2016"),
+                endDate: new Date(),
+                format: 'XML'
+            }, (error, data) => {
+                if (error) {
+                    return done();
+                }
+                done(new Error('Should have errored with bad access token'));
+            });
         });
     });
+
+    describe('when defined via AWQL', function(){
+        it('should return a valid report', function(done) {
+            let report = new AdwordsReport(config);
+
+            report.getReport('v201702', {
+                query: 'SELECT CampaignId, Impressions, Clicks, Cost FROM CAMPAIGN_PERFORMANCE_REPORT',
+                format: 'CSV' //defaults to CSV
+            }, done);
+        });
+
+        it('should return a valid report for xml type reports', function(done) {
+            let report = new AdwordsReport(config);
+
+            report.getReport('v201702', {
+                query: 'SELECT CampaignId, Impressions, Clicks, Cost FROM CAMPAIGN_PERFORMANCE_REPORT',
+                format: 'XML'
+            }, done);
+        });
+    });
+
 });


### PR DESCRIPTION
Before, it was only possible to query [Services](https://developers.google.com/adwords/api/docs/guides/awql#using_awql_in_service_calls) via AWQL.
But AWQL can also be quite handy to [generate reports](https://developers.google.com/adwords/api/docs/guides/awql#using_awql_with_reports), and in some cases, is the only way to pull out what you want. 
I think #24 was asking for this.