### PR TITLE
Bump soap package to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "request": "^2.81.0",
-    "soap": "^0.20.0",
+    "soap": "^0.23.0",
     "xmlbuilder": "^9.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the `soap` package dependency depends on the [debug](https://github.com/visionmedia/debug) package which's had a [regex vulnerability bug disclosed](https://nodesecurity.io/advisories/534) that has since been fixed. This failed our nsp check on the `node-adwords` version `201708.1.1`.

