### PR TITLE
Address case where report.format is xml and OAUTH error is in body

### DIFF
--- a/adwords/report.js
+++ b/adwords/report.js
@@ -69,7 +69,10 @@ class AdwordsReport {
      * @return {boolean}
      */
     reportBodyContainsError(report, body) {
-        if ('xml' !== (''+report.format).toLowerCase() && -1 !== body.indexOf('<?xml')) {
+        if (
+            'xml' !== (''+report.format).toLowerCase() && -1 !== body.indexOf('<?xml')
+            || body.toString().indexOf(AdwordsConstants.OAUTH_ERROR) !== -1
+        ) {
             return true;
         }
         return false;


### PR DESCRIPTION
Currently, the reportBodyContainsError method in the AdwordsReport class will always return `false` if the requested report format is XML, and therefore, never enters the body of this if statement where the access token refresh logic lives: https://github.com/ChrisAlvares/node-adwords/blob/master/adwords/report.js#L52

This update handles cases where report format is XML and the request resulted in an OAuth error.